### PR TITLE
Add RequestTaskModifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ supports different types of requests, including `DataTask`, `DownloadTask`, and
 
 One of the key features of RequestDL is its support for specifying properties of a
 request, such as `Query`, `Payload`, and `Headers`, among others. You can also use 
-`TaskModifier` and `TaskInterceptor` to process the response after the request is 
+`RequestTaskModifier` and `TaskInterceptor` to process the response after the request is 
 complete, allowing for actions like decoding, mapping, error handling based on status
 codes, and logging responses in the console.
 

--- a/Sources/RequestDL/Tasks/Sources/Modifier/Models/TaskModifier.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifier/Models/TaskModifier.swift
@@ -13,6 +13,7 @@ import Foundation
  The `task` function takes in a `Body` task and returns an `Element` value after applying
  the modification logic.
  */
+@available(*, deprecated, renamed: "RequestTaskModifier")
 public protocol TaskModifier<Element>: Sendable {
 
     /// The type of task being modified.

--- a/Sources/RequestDL/Tasks/Sources/Modifier/ModifiedTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifier/ModifiedTask.swift
@@ -13,6 +13,7 @@ import Foundation
  - Note: The `Element` associated type of the `ModifiedTask` is determined by the `Element`
  associated type of the `TaskModifier`.
  */
+@available(*, deprecated, renamed: "ModifiedRequestTask")
 public struct ModifiedTask<Modifier: TaskModifier>: RequestTask {
 
     public typealias Element = Modifier.Element

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Accept Only Status Code/Modifiers.AcceptOnlyStatusCode.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Accept Only Status Code/Modifiers.AcceptOnlyStatusCode.swift
@@ -7,7 +7,7 @@ import Foundation
 extension Modifiers {
 
     /// A modifier that accepts only a specific set of status codes as a successful result.
-    public struct AcceptOnlyStatusCode<Content: RequestTask>: TaskModifier where Content.Element: TaskResultPrimitive {
+    public struct AcceptOnlyStatusCode<Input: TaskResultPrimitive>: RequestTaskModifier {
 
         // MARK: - Internal properties
 
@@ -23,7 +23,7 @@ extension Modifiers {
          - Throws: An `InvalidStatusCodeError` if the status code of the result is not
          included in the set of accepted status codes.
          */
-        public func task(_ task: Content) async throws -> Content.Element {
+        public func body(_ task: Content) async throws -> Input {
             let result = try await task.result()
 
             guard
@@ -49,7 +49,7 @@ extension RequestTask where Element: TaskResultPrimitive {
      */
     public func acceptOnlyStatusCode(
         _ statusCodes: StatusCodeSet
-    ) -> ModifiedTask<Modifiers.AcceptOnlyStatusCode<Self>> {
-        modify(Modifiers.AcceptOnlyStatusCode(statusCodes: statusCodes))
+    ) -> ModifiedRequestTask<Modifiers.AcceptOnlyStatusCode<Element>> {
+        modifier(Modifiers.AcceptOnlyStatusCode(statusCodes: statusCodes))
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Decode/Modifiers.Decode.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Decode/Modifiers.Decode.swift
@@ -11,7 +11,7 @@ import Foundation
 extension Modifiers {
 
     /**
-     A `TaskModifier` that decodes the data returned by the `RequestTask` into a specified type
+     A `TaskInterceptor` that decodes the data returned by the `RequestTask` into a specified type
      using a `JSONDecoder`.
 
      Generic types:

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Extract Payload/Modifiers.ExtractPayload.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Extract Payload/Modifiers.ExtractPayload.swift
@@ -24,7 +24,10 @@ extension Modifiers {
      .extractPayload()
      ```
      */
-    public struct ExtractPayload<Content: RequestTask, Element>: TaskModifier where Content.Element == TaskResult<Element> {
+    public struct ExtractPayload<Output>: RequestTaskModifier {
+
+        public typealias Input = TaskResult<Output>
+
         // swiftlint:enable line_length
 
         /**
@@ -33,7 +36,7 @@ extension Modifiers {
          - Parameter task: The task to modify.
          - Returns: A new instance of `Payload` type that contains only the payload data.
          */
-        public func task(_ task: Content) async throws -> Element {
+        public func body(_ task: Content) async throws -> Output {
             try await task.result().payload
         }
     }
@@ -48,7 +51,7 @@ extension RequestTask {
 
      - Returns: A new modified task that contains only the data.
      */
-    public func extractPayload<T>() -> ModifiedTask<Modifiers.ExtractPayload<Self, T>> where Element == TaskResult<T> {
-        modify(Modifiers.ExtractPayload())
+    public func extractPayload<T>() -> ModifiedRequestTask<Modifiers.ExtractPayload<T>> where Element == TaskResult<T> {
+        modifier(Modifiers.ExtractPayload())
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Flat Map Error/Modifiers.FlatMapError.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Flat Map Error/Modifiers.FlatMapError.swift
@@ -7,7 +7,7 @@ import Foundation
 extension Modifiers {
 
     /**
-     A `TaskModifier` that maps the error of a `RequestTask` to a new `Error` type.
+     A `TaskInterceptor` that maps the error of a `RequestTask` to a new `Error` type.
 
      Use this modifier to transform the error type of a `RequestTask`. The `FlatMapError`
      modifier takes a closure that maps an error of the original task to a new error

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Flat Map Error/Modifiers.FlatMapError.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Flat Map Error/Modifiers.FlatMapError.swift
@@ -15,7 +15,7 @@ extension Modifiers {
      succeeds, the error is transformed to the new error type. If the closure fails,
      the task fails with the original error.
      */
-    public struct FlatMapError<Content: RequestTask>: TaskModifier {
+    public struct FlatMapError<Input: Sendable>: RequestTaskModifier {
 
         // MARK: - Internal properties
 
@@ -30,7 +30,7 @@ extension Modifiers {
          - Throws: An error if the transformation fails.
          - Returns: The result of the transformation.
          */
-        public func task(_ task: Content) async throws -> Content.Element {
+        public func body(_ task: Content) async throws -> Input {
             do {
                 return try await task.result()
             } catch {
@@ -68,8 +68,8 @@ extension RequestTask {
      */
     public func flatMapError(
         _ transform: @escaping @Sendable (Error) throws -> Void
-    ) -> ModifiedTask<Modifiers.FlatMapError<Self>> {
-        modify(Modifiers.FlatMapError(transform: transform))
+    ) -> ModifiedRequestTask<Modifiers.FlatMapError<Element>> {
+        modifier(Modifiers.FlatMapError(transform: transform))
     }
 
     /**
@@ -98,7 +98,7 @@ extension RequestTask {
     public func flatMapError<Failure: Error>(
         _ type: Failure.Type,
         _ transform: @escaping @Sendable (Failure) throws -> Void
-    ) -> ModifiedTask<Modifiers.FlatMapError<Self>> {
+    ) -> ModifiedRequestTask<Modifiers.FlatMapError<Element>> {
         flatMapError {
             if let error = $0 as? Failure {
                 try transform(error)

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Flat Map/Modifiers.FlatMap.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Flat Map/Modifiers.FlatMap.swift
@@ -21,16 +21,16 @@ extension Modifiers {
          }
      ```
      */
-    public struct FlatMap<Content: RequestTask, NewElement: Sendable>: TaskModifier {
+    public struct FlatMap<Input: Sendable, Output: Sendable>: RequestTaskModifier {
 
         enum Map: Sendable {
-            case original(Content.Element)
-            case processed(NewElement)
+            case original(Input)
+            case processed(Output)
         }
 
         // MARK: - Internal properties
 
-        let transform: @Sendable (Result<Content.Element, Error>) throws -> NewElement
+        let transform: @Sendable (Result<Input, Error>) throws -> Output
 
         // MARK: - Public methods
 
@@ -41,7 +41,7 @@ extension Modifiers {
          - Throws: An error if the transformation fails.
          - Returns: The result of the transformation.
          */
-        public func task(_ task: Content) async throws -> NewElement {
+        public func body(_ task: Content) async throws -> Output {
             switch await mapResponseIntoResult(task) {
             case .failure(let error):
                 throw error
@@ -88,7 +88,7 @@ extension RequestTask {
      */
     public func flatMap<NewElement>(
         _ transform: @escaping @Sendable (Result<Element, Error>) throws -> NewElement
-    ) -> ModifiedTask<Modifiers.FlatMap<Self, NewElement>> {
-        modify(Modifiers.FlatMap(transform: transform))
+    ) -> ModifiedRequestTask<Modifiers.FlatMap<Element, NewElement>> {
+        modifier(Modifiers.FlatMap(transform: transform))
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Key Path/Modifiers.KeyPath.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Key Path/Modifiers.KeyPath.swift
@@ -23,7 +23,7 @@ extension Modifiers {
          .keyPath(\.data)
      ```
      */
-    public struct KeyPath<Content: RequestTask>: TaskModifier {
+    public struct KeyPath<Input: Sendable>: RequestTaskModifier {
 
         // MARK: - Internal properties
 
@@ -31,8 +31,8 @@ extension Modifiers {
 
         // MARK: - Private properties
 
-        fileprivate let data: @Sendable (Content.Element) -> Data
-        fileprivate let element: @Sendable (Content.Element, Data) -> Content.Element
+        fileprivate let data: @Sendable (Input) -> Data
+        fileprivate let element: @Sendable (Input, Data) -> Input
 
         // MARK: - Public methods
 
@@ -43,7 +43,7 @@ extension Modifiers {
 
          - Returns: A `TaskResult` containing the extracted sub-value.
          */
-        public func task(_ task: Content) async throws -> Content.Element {
+        public func body(_ task: Content) async throws -> Input {
             let result = try await task.result()
 
             guard
@@ -78,8 +78,8 @@ extension RequestTask<TaskResult<Data>> {
 
      - Returns: A new `ModifiedTask` instance that applies the `KeyPath` modifier to the task.
      */
-    public func keyPath(_ keyPath: KeyPath<AbstractKeyPath, String>) -> ModifiedTask<Modifiers.KeyPath<Self>> {
-        modify(Modifiers.KeyPath(
+    public func keyPath(_ keyPath: KeyPath<AbstractKeyPath, String>) -> ModifiedRequestTask<Modifiers.KeyPath<Element>> {
+        modifier(Modifiers.KeyPath(
             keyPath: { $0[keyPath: keyPath] },
             data: \.payload,
             element: {
@@ -101,8 +101,8 @@ extension RequestTask<Data> {
 
      - Returns: A new `ModifiedTask` instance that applies the `KeyPath` modifier to the task.
      */
-    public func keyPath(_ keyPath: KeyPath<AbstractKeyPath, String>) -> ModifiedTask<Modifiers.KeyPath<Self>> {
-        modify(Modifiers.KeyPath(
+    public func keyPath(_ keyPath: KeyPath<AbstractKeyPath, String>) -> ModifiedRequestTask<Modifiers.KeyPath<Element>> {
+        modifier(Modifiers.KeyPath(
             keyPath: { $0[keyPath: keyPath] },
             data: { $0 },
             element: { $1 }

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Map Error/Modifiers.MapError.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Map Error/Modifiers.MapError.swift
@@ -8,11 +8,11 @@ extension Modifiers {
 
     /// A task modifier that applies a mapping function to the error of the task, allowing for
     /// error handling and transformation.
-    public struct MapError<Content: RequestTask>: TaskModifier {
+    public struct MapError<Input: Sendable>: RequestTaskModifier {
 
         // MARK: - Internal properties
 
-        let transform: @Sendable (Error) throws -> Element
+        let transform: @Sendable (Error) throws -> Input
 
         // MARK: - Public methods
 
@@ -23,7 +23,7 @@ extension Modifiers {
          to map.
          - Returns: A new error.
          */
-        public func task(_ task: Content) async throws -> Content.Element {
+        public func body(_ task: Content) async throws -> Input {
             do {
                 return try await task.result()
             } catch {
@@ -46,7 +46,7 @@ extension RequestTask {
      */
     public func mapError(
         _ transform: @escaping @Sendable (Error) throws -> Element
-    ) -> ModifiedTask<Modifiers.MapError<Self>> {
-        modify(Modifiers.MapError(transform: transform))
+    ) -> ModifiedRequestTask<Modifiers.MapError<Element>> {
+        modifier(Modifiers.MapError(transform: transform))
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Map/Modifiers.Map.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Map/Modifiers.Map.swift
@@ -7,7 +7,7 @@ import Foundation
 extension Modifiers {
 
     /**
-     A `TaskModifier` that transforms the element of the given `RequestTask` using the
+     A `TaskInterceptor` that transforms the element of the given `RequestTask` using the
      provided closure.
 
      Use the `map` modifier to transform the `Element` of a `RequestTask` to a different type

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Map/Modifiers.Map.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Map/Modifiers.Map.swift
@@ -25,11 +25,11 @@ extension Modifiers {
      In this example, the `RequestTask` produces `Data` elements, but you can use the `map`
      modifier to decode them into `MyModel` instances instead.
      */
-    public struct Map<Content: RequestTask, NewElement: Sendable>: TaskModifier {
+    public struct Map<Input: Sendable, Output: Sendable>: RequestTaskModifier {
 
         // MARK: - Internal properties
 
-        let transform: @Sendable (Content.Element) throws -> NewElement
+        let transform: @Sendable (Input) throws -> Output
 
         // MARK: - Public methods
 
@@ -40,7 +40,7 @@ extension Modifiers {
          - Returns: The transformed element.
          - Throws: The error thrown by the closure, if any.
          */
-        public func task(_ task: Content) async throws -> NewElement {
+        public func body(_ task: Content) async throws -> Output {
             try transform(await task.result())
         }
     }
@@ -58,7 +58,7 @@ extension RequestTask {
      */
     public func map<NewElement>(
         _ transform: @escaping @Sendable (Element) throws -> NewElement
-    ) -> ModifiedTask<Modifiers.Map<Self, NewElement>> {
-        modify(Modifiers.Map(transform: transform))
+    ) -> ModifiedRequestTask<Modifiers.Map<Element, NewElement>> {
+        modifier(Modifiers.Map(transform: transform))
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/RequestTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/RequestTask.swift
@@ -60,12 +60,21 @@ extension RequestTask {
      modify its result.
      */
     @available(*, deprecated, renamed: "modifier")
-    public func modify<Modifier: RequestTaskModifier>(
+    public func modify<Modifier: TaskModifier>(
         _ modifier: Modifier
     ) -> ModifiedTask<Modifier> where Modifier.Body == Self {
         ModifiedTask(task: self, modifier: modifier)
     }
 
+    /**
+     Returns a `ModifiedRequestTask` that executes the original task and modifies its result using
+     the provided `RequestTaskModifier`.
+
+     - Parameter modifier: A `RequestTaskModifier` that modifies the result of the task.
+
+     - Returns: A `ModifiedRequestTask` object that can be used to execute the original task and
+     modify its result.
+     */
     public func modifier<Modifier: RequestTaskModifier>(
         _ modifier: Modifier
     ) -> ModifiedRequestTask<Modifier> where Modifier.Input == Element {

--- a/Sources/RequestDL/Tasks/Sources/RequestTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/RequestTask.swift
@@ -59,10 +59,20 @@ extension RequestTask {
      - Returns: A `ModifiedTask` object that can be used to execute the original task and
      modify its result.
      */
-    public func modify<Modifier: TaskModifier>(
+    @available(*, deprecated, renamed: "modifier")
+    public func modify<Modifier: RequestTaskModifier>(
         _ modifier: Modifier
     ) -> ModifiedTask<Modifier> where Modifier.Body == Self {
         ModifiedTask(task: self, modifier: modifier)
+    }
+
+    public func modifier<Modifier: RequestTaskModifier>(
+        _ modifier: Modifier
+    ) -> ModifiedRequestTask<Modifier> where Modifier.Input == Element {
+        ModifiedRequestTask(
+            task: .init(self),
+            modifier: modifier
+        )
     }
 }
 

--- a/Sources/RequestDL/Tasks/Sources/Task Modifier/Models/RequestTaskModifier.swift
+++ b/Sources/RequestDL/Tasks/Sources/Task Modifier/Models/RequestTaskModifier.swift
@@ -1,0 +1,16 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+public protocol RequestTaskModifier<Input, Output>: Sendable {
+
+    typealias Content = _RequestTaskModifier_Content<Self>
+
+    associatedtype Input: Sendable
+
+    associatedtype Output: Sendable
+
+    func body(_ task: Self.Content) async throws -> Output
+}

--- a/Sources/RequestDL/Tasks/Sources/Task Modifier/Models/_RequestTaskModifier_Content.swift
+++ b/Sources/RequestDL/Tasks/Sources/Task Modifier/Models/_RequestTaskModifier_Content.swift
@@ -1,0 +1,24 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+public struct _RequestTaskModifier_Content<Modifier: RequestTaskModifier>: RequestTask {
+
+    // MARK: - Private properties
+
+    private let task: any RequestTask<Modifier.Input>
+
+    // MARK: - Inits
+
+    init<Content: RequestTask>(_ task: Content) where Content.Element == Modifier.Input {
+        self.task = task
+    }
+
+    // MARK: - Public methods
+
+    public func result() async throws -> Modifier.Input {
+        try await task.result()
+    }
+}

--- a/Sources/RequestDL/Tasks/Sources/Task Modifier/Models/_RequestTaskModifier_Content.swift
+++ b/Sources/RequestDL/Tasks/Sources/Task Modifier/Models/_RequestTaskModifier_Content.swift
@@ -4,6 +4,8 @@
 
 import Foundation
 
+/// This struct is marked as internal and is not intended
+/// to be used directly by clients of this framework.
 public struct _RequestTaskModifier_Content<Modifier: RequestTaskModifier>: RequestTask {
 
     // MARK: - Private properties

--- a/Sources/RequestDL/Tasks/Sources/Task Modifier/ModifiedRequestTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Task Modifier/ModifiedRequestTask.swift
@@ -4,6 +4,15 @@
 
 import Foundation
 
+/**
+ A type that represents a task that has been modified by a `RequestTaskModifier`.
+
+ A `ModifiedRequestTask` is a `RequestTask` that is created by applying a
+ `RequestTaskModifier` to a base `RequestTask`.
+
+ - Note: The `Element` associated type of the `ModifiedTask` is determined by the `Output`
+ associated type of the `RequestTaskModifier`.
+ */
 public struct ModifiedRequestTask<Modifier: RequestTaskModifier>: RequestTask {
 
     public typealias Element = Modifier.Output

--- a/Sources/RequestDL/Tasks/Sources/Task Modifier/ModifiedRequestTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Task Modifier/ModifiedRequestTask.swift
@@ -1,0 +1,28 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+public struct ModifiedRequestTask<Modifier: RequestTaskModifier>: RequestTask {
+
+    public typealias Element = Modifier.Output
+
+    // MARK: - Internal properties
+
+    let task: Modifier.Content
+    let modifier: Modifier
+
+    // MARK: - Public properties
+
+    /**
+     Returns the result of the task.
+
+     - Throws: An error of type `Error` if the task could not be completed.
+
+     - Returns: An object of type `Element` with the result of the task.
+     */
+    public func result() async throws -> Element {
+        try await modifier.body(task)
+    }
+}

--- a/Tests/RequestDLTests/Tasks/Sources/Modifier/ModifiedTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifier/ModifiedTaskTests.swift
@@ -7,11 +7,11 @@ import XCTest
 
 class ModifiedTaskTests: XCTestCase {
 
-    struct Modified<Body: RequestTask>: TaskModifier {
+    struct Modified<Input: Sendable>: RequestTaskModifier {
 
         let callback: @Sendable () -> Void
 
-        func task(_ task: Body) async throws -> Body.Element {
+        func body(_ task: Content) async throws -> some Sendable {
             callback()
             return try await task.result()
         }
@@ -25,7 +25,7 @@ class ModifiedTaskTests: XCTestCase {
         _ = try await MockedTask {
             BaseURL("localhost")
         }
-        .modify(Modified {
+        .modifier(Modified {
             taskModified(true)
         })
         .result()

--- a/Tests/RequestDLTests/Tasks/Sources/Task Modifier/ModifiedRequestTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Task Modifier/ModifiedRequestTaskTests.swift
@@ -5,14 +5,13 @@
 import XCTest
 @testable import RequestDL
 
-@available(*, deprecated)
-class ModifiedTaskTests: XCTestCase {
+class ModifiedRequestTaskTests: XCTestCase {
 
-    struct Modified<Content: RequestTask>: TaskModifier {
+    struct Modified<Input: Sendable>: RequestTaskModifier {
 
         let callback: @Sendable () -> Void
 
-        func task(_ task: Content) async throws -> Content.Element {
+        func body(_ task: Content) async throws -> Input {
             callback()
             return try await task.result()
         }
@@ -26,7 +25,7 @@ class ModifiedTaskTests: XCTestCase {
         _ = try await MockedTask {
             BaseURL("localhost")
         }
-        .modify(Modified {
+        .modifier(Modified {
             taskModified(true)
         })
         .result()


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

This MR introduces the brand new `RequestTaskModifier` that offers an improved syntax for creating custom modifiers. Previously, it had a dependency on the Body task that needed modification, but now it has been decoupled from it. The changes now specifically define the Input and Output for the element only.

You should implement this if you want to modify the Input to Output.

```swift
struct ExampleModifier<Input, Output>: RequestTaskModifier {

    func body(_ task: Content) -> Output {}
}
```

Alternatively, if you prefer to maintain the original output:

```swift
struct ExampleModifier<Input>: RequestTaskModifier {

    func body(_ task: Content) -> Input {}
}
```

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
