### PR TITLE
Add TaskEnvironment

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/Models/PropertyEnvironmentValues.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/Models/PropertyEnvironmentValues.swift
@@ -6,8 +6,7 @@ import Foundation
 
 /**
  `PropertyEnvironmentValues` is a type that contains all of the environment values
- for a view hierarchy. It is accessible via a subscript on a view's `PropertyEnvironment`
- property.
+ for a property hierarchy. It is accessible via a subscript on a property's `PropertyEnvironment` wrapper.
  */
 public struct PropertyEnvironmentValues: Sendable {
 
@@ -25,7 +24,7 @@ public struct PropertyEnvironmentValues: Sendable {
      Subscript for retrieving an `Value` for a given `PropertyEnvironmentKey` type.
 
      - Parameter key: The `PropertyEnvironmentKey` type to retrieve the `Value` for.
-     - Returns: The `Value` in the environment for the given `key`.
+     - Returns: The `Value` in the environment for the given `Key`.
      */
     public subscript<Key: PropertyEnvironmentKey>(key: Key.Type) -> Key.Value {
         get {

--- a/Sources/RequestDL/Tasks/Sources/Any/AnyTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Any/AnyTask.swift
@@ -22,14 +22,22 @@ import Foundation
  */
 public struct AnyTask<Element: Sendable>: RequestTask {
 
+    // MARK: - Public properties
+
+    @_spi(Private)
+    public var environment: TaskEnvironmentValues {
+        get { task.environment }
+        set { task.environment = newValue }
+    }
+
     // MARK: - Private properties
 
-    private let wrapper: @Sendable () async throws -> Element
+    private var task: any RequestTask<Element>
 
     // MARK: - Inits
 
     init<T: RequestTask>(_ task: T) where T.Element == Element {
-        wrapper = { try await task.result() }
+        self.task = task
     }
 
     // MARK: - Public methods
@@ -42,7 +50,7 @@ public struct AnyTask<Element: Sendable>: RequestTask {
      - Throws: If the wrapped task throws an error.
      */
     public func result() async throws -> Element {
-        try await wrapper()
+        try await task.result()
     }
 }
 

--- a/Sources/RequestDL/Tasks/Sources/Group/GroupTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Group/GroupTask.swift
@@ -33,6 +33,9 @@ import Foundation
 public struct GroupTask<Data: Sequence, Content: RequestTask>: RequestTask where Data.Element: Hashable, Data: Sendable {
     // swiftlint:enable line_length
 
+    @_spi(Private)
+    public var environment = TaskEnvironmentValues()
+
     // MARK: - Private properties
 
     private let data: Data
@@ -65,7 +68,9 @@ public struct GroupTask<Data: Sequence, Content: RequestTask>: RequestTask where
               for element in data {
                   group.addTask {
                       do {
-                          return (element, .success(try await transform(element).result()))
+                          var task = transform(element)
+                          task.environment = environment
+                          return (element, .success(try await task.result()))
                       } catch {
                           return (element, .failure(error))
                       }

--- a/Sources/RequestDL/Tasks/Sources/Interceptor/InterceptedTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Interceptor/InterceptedTask.swift
@@ -20,9 +20,17 @@ public struct InterceptedTask<
 
     public typealias Element = Content.Element
 
+    // MARK: - Public properties
+
+    @_spi(Private)
+    public var environment: TaskEnvironmentValues {
+        get { task.environment }
+        set { task.environment = newValue }
+    }
+
     // MARK: - Internal properties
 
-    let task: Content
+    var task: Content
     let interceptor: Interceptor
 
     // MARK: - Public methods

--- a/Sources/RequestDL/Tasks/Sources/Mocked/MockedTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Mocked/MockedTask.swift
@@ -33,6 +33,11 @@ import Foundation
 */
 public struct MockedTask<Element: Sendable>: RequestTask {
 
+    // MARK: - Public properties
+
+    @_spi(Private)
+    public var environment = TaskEnvironmentValues()
+
     // MARK: - Private properties
 
     private let payload: any MockedTaskPayload<Element>

--- a/Sources/RequestDL/Tasks/Sources/Modifier/ModifiedTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifier/ModifiedTask.swift
@@ -18,9 +18,17 @@ public struct ModifiedTask<Modifier: TaskModifier>: RequestTask {
 
     public typealias Element = Modifier.Element
 
+    // MARK: - Public properties
+
+    @_spi(Private)
+    public var environment: TaskEnvironmentValues {
+        get { task.environment }
+        set { task.environment = newValue }
+    }
+
     // MARK: - Internal properties
 
-    let task: Modifier.Body
+    var task: Modifier.Body
     let modifier: Modifier
 
     // MARK: - Public properties

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Environment/Modifiers.Environment.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Environment/Modifiers.Environment.swift
@@ -5,10 +5,10 @@
 import Foundation
 
 extension Modifiers {
-    
+
     /**
      A modifier that updates the environment of `RequestTask` without changing the output.
-     
+
      - Note: This modifier requires the `RequestTask` to conform to `Sendable`.
      */
     public struct Environment<Input: Sendable>: RequestTaskModifier {

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Environment/Modifiers.Environment.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Environment/Modifiers.Environment.swift
@@ -1,0 +1,35 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+extension Modifiers {
+
+    public struct Environment<Input: Sendable>: RequestTaskModifier {
+
+        // MARK: - Internal properties
+
+        let update: @Sendable (inout TaskEnvironmentValues) -> Void
+
+        // MARK: - Public methods
+
+        public func body(_ task: Content) async throws -> Input {
+            var task = task
+            update(&task.environment)
+            return try await task.result()
+        }
+    }
+}
+
+extension RequestTask {
+
+    public func environment<Value: Sendable>(
+        _ keyPath: WritableKeyPath<TaskEnvironmentValues, Value>,
+        _ value: Value
+    ) -> ModifiedRequestTask<Modifiers.Environment<Element>> {
+        modifier(Modifiers.Environment {
+            $0[keyPath: keyPath] = value
+        })
+    }
+}

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Environment/Modifiers.Environment.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Environment/Modifiers.Environment.swift
@@ -5,7 +5,12 @@
 import Foundation
 
 extension Modifiers {
-
+    
+    /**
+     A modifier that updates the environment of `RequestTask` without changing the output.
+     
+     - Note: This modifier requires the `RequestTask` to conform to `Sendable`.
+     */
     public struct Environment<Input: Sendable>: RequestTaskModifier {
 
         // MARK: - Internal properties
@@ -14,6 +19,13 @@ extension Modifiers {
 
         // MARK: - Public methods
 
+        /**
+         Updates the environment of `RequestTask` without changing the output.
+
+         - Parameter task: The original `RequestTask`.
+         - Throws: An error thrown by the original task.
+         - Returns: The result of the original task.
+         */
         public func body(_ task: Content) async throws -> Input {
             var task = task
             update(&task.environment)
@@ -24,6 +36,14 @@ extension Modifiers {
 
 extension RequestTask {
 
+    /**
+     Applies an environment modifier to the `RequestTask` using the provided key path and value.
+
+     - Parameters:
+        - keyPath: The key path to the environment value.
+        - value: The new value to set for the environment value.
+     - Returns: A modified `RequestTask` with the applied environment modifier.
+     */
     public func environment<Value: Sendable>(
         _ keyPath: WritableKeyPath<TaskEnvironmentValues, Value>,
         _ value: Value

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Extract Payload/Modifiers.ExtractPayload.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Extract Payload/Modifiers.ExtractPayload.swift
@@ -6,7 +6,6 @@ import Foundation
 
 extension Modifiers {
 
-    // swiftlint:disable line_length
     /**
      A task modifier that extracts only the payload from a task result.
 
@@ -27,8 +26,6 @@ extension Modifiers {
     public struct ExtractPayload<Output>: RequestTaskModifier {
 
         public typealias Input = TaskResult<Output>
-
-        // swiftlint:enable line_length
 
         /**
          Modifies the task to extract only the payload from a task result.

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Ignores Progress/Modifiers.IgnoresProgress.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Ignores Progress/Modifiers.IgnoresProgress.swift
@@ -2,7 +2,6 @@
  See LICENSE for this package's licensing information.
 */
 
-
 #if canImport(Darwin)
 import Foundation
 #else
@@ -84,6 +83,7 @@ extension Modifiers {
 
 // MARK: - RequestTask extension
 
+// swiftlint:disable line_length
 extension RequestTask {
 
     public func ignoresProgress() -> ModifiedRequestTask<Modifiers.IgnoresProgress<Element, TaskResult<Data>>>
@@ -106,3 +106,4 @@ extension RequestTask {
         modifier(Modifiers.IgnoresProgress())
     }
 }
+// swiftlint:enable line_length

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Key Path/Modifiers.KeyPath.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Key Path/Modifiers.KeyPath.swift
@@ -78,7 +78,9 @@ extension RequestTask<TaskResult<Data>> {
 
      - Returns: A new `ModifiedTask` instance that applies the `KeyPath` modifier to the task.
      */
-    public func keyPath(_ keyPath: KeyPath<AbstractKeyPath, String>) -> ModifiedRequestTask<Modifiers.KeyPath<Element>> {
+    public func keyPath(
+        _ keyPath: KeyPath<AbstractKeyPath, String>
+    ) -> ModifiedRequestTask<Modifiers.KeyPath<Element>> {
         modifier(Modifiers.KeyPath(
             keyPath: { $0[keyPath: keyPath] },
             data: \.payload,
@@ -101,7 +103,9 @@ extension RequestTask<Data> {
 
      - Returns: A new `ModifiedTask` instance that applies the `KeyPath` modifier to the task.
      */
-    public func keyPath(_ keyPath: KeyPath<AbstractKeyPath, String>) -> ModifiedRequestTask<Modifiers.KeyPath<Element>> {
+    public func keyPath(
+        _ keyPath: KeyPath<AbstractKeyPath, String>
+    ) -> ModifiedRequestTask<Modifiers.KeyPath<Element>> {
         modifier(Modifiers.KeyPath(
             keyPath: { $0[keyPath: keyPath] },
             data: { $0 },

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Data/DataTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Data/DataTask.swift
@@ -27,9 +27,17 @@ import Foundation
  */
 public struct DataTask<Content: Property>: RequestTask {
 
+    // MARK: - Public properties
+
+    @_spi(Private)
+    public var environment: TaskEnvironmentValues {
+        get { task.environment }
+        set { task.environment = newValue }
+    }
+
     // MARK: - Private properties
 
-    private let content: Content
+    private var task: RawTask<Content>
 
     // MARK: - Inits
 
@@ -39,7 +47,7 @@ public struct DataTask<Content: Property>: RequestTask {
      - Parameter content: The content of the request.
      */
     public init(@PropertyBuilder content: () -> Content) {
-        self.content = content()
+        self.task = RawTask(content: content())
     }
 
     // MARK: - Public methods
@@ -56,7 +64,7 @@ public struct DataTask<Content: Property>: RequestTask {
      - Throws: An error of type `Error` that indicates an issue with the request or response.
      */
     public func result() async throws -> TaskResult<Data> {
-        try await RawTask(content: content)
+        try await task
             .ignoresProgress()
             .result()
     }

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Download/DownloadTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Download/DownloadTask.swift
@@ -55,9 +55,17 @@ import Foundation
  */
 public struct DownloadTask<Content: Property>: RequestTask {
 
+    // MARK: - Public properties
+
+    @_spi(Private)
+    public var environment: TaskEnvironmentValues {
+        get { task.environment }
+        set { task.environment = newValue }
+    }
+
     // MARK: - Private properties
 
-    private let content: Content
+    private var task: RawTask<Content>
 
     // MARK: - Inits
 
@@ -67,7 +75,7 @@ public struct DownloadTask<Content: Property>: RequestTask {
      - Parameter content: The content of the request.
      */
     public init(@PropertyBuilder content: () -> Content) {
-        self.content = content()
+        self.task = RawTask(content: content())
     }
 
     // MARK: - Public methods
@@ -85,7 +93,7 @@ public struct DownloadTask<Content: Property>: RequestTask {
      - Throws: An error of type `Error` that indicates an issue with the request or response.
      */
     public func result() async throws -> TaskResult<AsyncBytes> {
-        try await RawTask(content: content)
+        try await task
             .ignoresUploadProgress()
             .result()
     }

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/RawTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/RawTask.swift
@@ -6,6 +6,11 @@ import Foundation
 
 struct RawTask<Content: Property>: RequestTask {
 
+    // MARK: - Public properties
+
+    @_spi(Private)
+    public var environment = TaskEnvironmentValues()
+
     // MARK: - Internal properties
 
     let content: Content

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Upload/UploadTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Upload/UploadTask.swift
@@ -39,9 +39,17 @@ import Foundation
  */
 public struct UploadTask<Content: Property>: RequestTask {
 
+    // MARK: - Public properties
+
+    @_spi(Private)
+    public var environment: TaskEnvironmentValues {
+        get { task.environment }
+        set { task.environment = newValue }
+    }
+
     // MARK: - Private properties
 
-    private let content: Content
+    private var task: RawTask<Content>
 
     // MARK: - Inits
 
@@ -51,7 +59,7 @@ public struct UploadTask<Content: Property>: RequestTask {
      - Parameter content: The content of the request.
      */
     public init(@PropertyBuilder content: () -> Content) {
-        self.content = content()
+        self.task = RawTask(content: content())
     }
 
     // MARK: - Public methods
@@ -69,6 +77,6 @@ public struct UploadTask<Content: Property>: RequestTask {
      - Throws: An error of type `Error` that indicates an issue with the request or response.
      */
     public func result() async throws -> AsyncResponse {
-        try await RawTask(content: content).result()
+        try await task.result()
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Request Task/Models/RequestTaskInternals.swift
+++ b/Sources/RequestDL/Tasks/Sources/Request Task/Models/RequestTaskInternals.swift
@@ -1,0 +1,11 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+public protocol RequestTaskInternals: Sendable {
+
+    @_spi(Private)
+    var environment: TaskEnvironmentValues { get set }
+}

--- a/Sources/RequestDL/Tasks/Sources/Request Task/Models/RequestTaskInternals.swift
+++ b/Sources/RequestDL/Tasks/Sources/Request Task/Models/RequestTaskInternals.swift
@@ -4,7 +4,8 @@
 
 import Foundation
 
-public protocol RequestTaskInternals: Sendable {
+/// This protocol is marked as internal and is not intended to be used directly by clients of this framework.
+public protocol _RequestTaskInternals: Sendable {
 
     @_spi(Private)
     var environment: TaskEnvironmentValues { get set }

--- a/Sources/RequestDL/Tasks/Sources/Request Task/Models/TaskEnvironmentKey.swift
+++ b/Sources/RequestDL/Tasks/Sources/Request Task/Models/TaskEnvironmentKey.swift
@@ -1,0 +1,12 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+public protocol TaskEnvironmentKey: Sendable {
+
+    associatedtype Value: Sendable
+
+    static var defaultValue: Value { get }
+}

--- a/Sources/RequestDL/Tasks/Sources/Request Task/Models/TaskEnvironmentKey.swift
+++ b/Sources/RequestDL/Tasks/Sources/Request Task/Models/TaskEnvironmentKey.swift
@@ -4,9 +4,14 @@
 
 import Foundation
 
+/**
+ The `TaskEnvironmentKey` protocol defines a type that can be used as a key to
+ retrieve an `Value` from `TaskEnvironmentValues`.
+ */
 public protocol TaskEnvironmentKey: Sendable {
 
     associatedtype Value: Sendable
 
+    /// The default value for this `TaskEnvironmentKey`.
     static var defaultValue: Value { get }
 }

--- a/Sources/RequestDL/Tasks/Sources/Request Task/Models/TaskEnvironmentValues.swift
+++ b/Sources/RequestDL/Tasks/Sources/Request Task/Models/TaskEnvironmentValues.swift
@@ -1,0 +1,36 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+public struct TaskEnvironmentValues: @unchecked Sendable {
+
+    // MARK: - Private properties
+
+    private let lock = Lock()
+
+    // MARK: - Unsafe properties
+
+    private var _dependencies = [ObjectIdentifier: Sendable]()
+
+    // MARK: - Inits
+
+    init() {}
+
+    // MARK: - Public methods
+
+    public subscript<Key: TaskEnvironmentKey>(_ keyType: Key.Type) -> Key.Value {
+        get {
+            lock.withLock {
+                let value = _dependencies[ObjectIdentifier(keyType)] as? Key.Value
+                return value ?? Key.defaultValue
+            }
+        }
+        set {
+            lock.withLock {
+                _dependencies[ObjectIdentifier(keyType)] = newValue
+            }
+        }
+    }
+}

--- a/Sources/RequestDL/Tasks/Sources/Request Task/Models/TaskEnvironmentValues.swift
+++ b/Sources/RequestDL/Tasks/Sources/Request Task/Models/TaskEnvironmentValues.swift
@@ -4,15 +4,12 @@
 
 import Foundation
 
+/// `TaskEnvironmentValues` is a type that contains all of the environment values for a task.
 public struct TaskEnvironmentValues: @unchecked Sendable {
-
-    // MARK: - Private properties
-
-    private let lock = Lock()
 
     // MARK: - Unsafe properties
 
-    private var _dependencies = [ObjectIdentifier: Sendable]()
+    private var dependencies = [ObjectIdentifier: Sendable]()
 
     // MARK: - Inits
 
@@ -20,17 +17,19 @@ public struct TaskEnvironmentValues: @unchecked Sendable {
 
     // MARK: - Public methods
 
+    /**
+     Subscript for retrieving an `Value` for a given `TaskEnvironmentKey` type.
+
+     - Parameter key: The `TaskEnvironmentKey` type to retrieve the `Value` for.
+     - Returns: The `Value` in the environment for the given `Key`.
+     */
     public subscript<Key: TaskEnvironmentKey>(_ keyType: Key.Type) -> Key.Value {
         get {
-            lock.withLock {
-                let value = _dependencies[ObjectIdentifier(keyType)] as? Key.Value
-                return value ?? Key.defaultValue
-            }
+            let value = dependencies[ObjectIdentifier(keyType)] as? Key.Value
+            return value ?? Key.defaultValue
         }
         set {
-            lock.withLock {
-                _dependencies[ObjectIdentifier(keyType)] = newValue
-            }
+            dependencies[ObjectIdentifier(keyType)] = newValue
         }
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Request Task/RequestTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Request Task/RequestTask.swift
@@ -17,7 +17,7 @@ import Foundation
  - Note: The RequestTask protocol does not specify how the request is made or how the result is processed,
  it only provides a way to execute a request and receive its result asynchronously.
  */
-public protocol RequestTask<Element>: RequestTaskInternals {
+public protocol RequestTask<Element>: _RequestTaskInternals {
 
     associatedtype Element: Sendable
 

--- a/Sources/RequestDL/Tasks/Sources/Request Task/RequestTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Request Task/RequestTask.swift
@@ -17,7 +17,7 @@ import Foundation
  - Note: The RequestTask protocol does not specify how the request is made or how the result is processed,
  it only provides a way to execute a request and receive its result asynchronously.
  */
-public protocol RequestTask<Element>: Sendable {
+public protocol RequestTask<Element>: RequestTaskInternals {
 
     associatedtype Element: Sendable
 

--- a/Sources/RequestDL/Tasks/Sources/Task Modifier/Models/_RequestTaskModifier_Content.swift
+++ b/Sources/RequestDL/Tasks/Sources/Task Modifier/Models/_RequestTaskModifier_Content.swift
@@ -8,9 +8,17 @@ import Foundation
 /// to be used directly by clients of this framework.
 public struct _RequestTaskModifier_Content<Modifier: RequestTaskModifier>: RequestTask {
 
+    // MARK: - Public properties
+
+    @_spi(Private)
+    public var environment: TaskEnvironmentValues {
+        get { task.environment }
+        set { task.environment = newValue }
+    }
+
     // MARK: - Private properties
 
-    private let task: any RequestTask<Modifier.Input>
+    private var task: any RequestTask<Modifier.Input>
 
     // MARK: - Inits
 

--- a/Sources/RequestDL/Tasks/Sources/Task Modifier/ModifiedRequestTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Task Modifier/ModifiedRequestTask.swift
@@ -17,9 +17,17 @@ public struct ModifiedRequestTask<Modifier: RequestTaskModifier>: RequestTask {
 
     public typealias Element = Modifier.Output
 
+    // MARK: - Public properties
+
+    @_spi(Private)
+    public var environment: TaskEnvironmentValues {
+        get { task.environment }
+        set { task.environment = newValue }
+    }
+
     // MARK: - Internal properties
 
-    let task: Modifier.Content
+    var task: Modifier.Content
     let modifier: Modifier
 
     // MARK: - Public properties

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Environment/ModifiersEnvironmentTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Environment/ModifiersEnvironmentTests.swift
@@ -1,0 +1,56 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+import XCTest
+@testable import RequestDL
+
+class ModifiersEnvironmentTests: XCTestCase {
+
+    struct NumberTask: RequestTask {
+
+        var environment = RequestDL.TaskEnvironmentValues()
+
+        func result() async throws -> Int {
+            environment.number
+        }
+    }
+
+    func testEnvironment_whenNotSet() async throws {
+        // Given
+        let numberTask = NumberTask()
+
+        // When
+        let value = try await numberTask.result()
+
+        // Then
+        XCTAssertEqual(value, 1)
+    }
+
+    func testEnvironment_whenUpdatedWithValue() async throws {
+        // Given
+        let number = 2
+        let numberTask = NumberTask()
+
+        // When
+        let value = try await numberTask
+            .environment(\.number, number)
+            .result()
+
+        // Then
+        XCTAssertEqual(value, number)
+    }
+}
+
+private struct NumberKey: TaskEnvironmentKey {
+    static let defaultValue = 1
+}
+
+extension TaskEnvironmentValues {
+
+    fileprivate var number: Int {
+        get { self[NumberKey.self] }
+        set { self[NumberKey.self] = newValue }
+    }
+}

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Map Error/ModifiersMapErrorTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Map Error/ModifiersMapErrorTests.swift
@@ -9,29 +9,27 @@ class ModifiersMapErrorTests: XCTestCase {
 
     struct AnyError: Error {}
 
-    struct ErrorTask<T>: RequestTask {
-
-        func result() async throws -> T {
-            throw AnyError()
-        }
-    }
-
     func testMapError() async throws {
         // Given
         let output = 1
         let invalidOutput = 2
 
         // When
-        let result = try await ErrorTask<Int>()
-            .mapError {
-                switch $0 {
-                case is AnyError:
-                    return output
-                default:
-                    return invalidOutput
-                }
+        let result = try await MockedTask(content: {
+            AsyncProperty {
+                throw AnyError()
             }
-            .result()
+        })
+        .map { _ in Int.zero }
+        .mapError {
+            switch $0 {
+            case is AnyError:
+                return output
+            default:
+                return invalidOutput
+            }
+        }
+        .result()
 
         // Then
         XCTAssertEqual(result, output)


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

This PR enables the TaskEnvironment internally so we can set values at `RequestTask` level. This feature will be explored in the next PR which will implement the integration with Swift Log. 

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
