### PR TITLE
Fix `HeaderStrategy` default value

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Header Node/Models/HeaderStrategyKey.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Header Node/Models/HeaderStrategyKey.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 private struct HeaderStrategyKey: PropertyEnvironmentKey {
-    static let defaultValue: HeaderStrategy = .setting
+    static let defaultValue: HeaderStrategy = .adding
 }
 
 extension PropertyEnvironmentValues {

--- a/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
@@ -115,14 +115,14 @@ extension ResolveTests {
                     property = HeaderNode {
                         key = Accept,
                         value = application/json,
-                        strategy = .setting
+                        strategy = .adding
                     }
                 },
                 LeafNode<HeaderNode> {
                     property = HeaderNode {
                         key = Cache-Control,
                         value = public,
-                        strategy = .setting
+                        strategy = .adding
                     }
                 },
                 LeafNode<Node> {
@@ -174,14 +174,14 @@ extension ResolveTests {
                                 property = HeaderNode {
                                     key = Accept,
                                     value = application/json,
-                                    strategy = .setting
+                                    strategy = .adding
                                 }
                             },
                             LeafNode<HeaderNode> {
                                 property = HeaderNode {
                                     key = Cache-Control,
                                     value = public,
-                                    strategy = .setting
+                                    strategy = .adding
                                 }
                             }
                         ]

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Header Group/HeaderGroupTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Header Group/HeaderGroupTests.swift
@@ -93,7 +93,6 @@ class HeaderGroupTests: XCTestCase {
                 AcceptHeader(.gif)
                 AcceptHeader(.html)
             }
-            .headerStrategy(.adding)
         })
 
         // Then

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/HeadersTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/HeadersTests.swift
@@ -36,6 +36,7 @@ class HeadersTests: XCTestCase {
             CustomHeader(name: "xxx-api-key", value: "password")
             CustomHeader(name: "xxx-api-key", value: "password123")
         }
+        .headerStrategy(.setting)
 
         let resolved = try await resolve(property)
 
@@ -59,6 +60,7 @@ class HeadersTests: XCTestCase {
                 CustomHeader(name: "xxx-api-key", value: "password123")
             }
         }
+        .headerStrategy(.setting)
 
         let resolved = try await resolve(property)
 
@@ -80,7 +82,6 @@ class HeadersTests: XCTestCase {
             CustomHeader(name: "xxx-api-key", value: "password")
             CustomHeader(name: "xxx-api-key", value: "password123")
         }
-        .headerStrategy(.adding)
 
         // When
         let resolved = try await resolve(property)
@@ -115,7 +116,6 @@ class HeadersTests: XCTestCase {
                 CustomHeader(name: "xxx-api-key", value: "password123")
             }
         }
-        .headerStrategy(.adding)
 
         // When
         let resolved = try await resolve(property)

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Form/FormTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Form/FormTests.swift
@@ -1127,7 +1127,6 @@ class FormTests: XCTestCase {
                 headers: {
                     CustomHeader(name: "Accept-Language", value: "en-US")
                     CustomHeader(name: "Accept-Language", value: "pt-BR")
-                        .headerStrategy(.adding)
                 }
             )
         })

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Form/FormTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Form/FormTests.swift
@@ -1159,6 +1159,51 @@ class FormTests: XCTestCase {
         ])
     }
 
+    func testForm_whenHeadersWithSettingStrategy() async throws {
+        // Given
+        let name = "foo"
+        let data = Data.randomData(length: 64)
+
+        // When
+        let resolved = try await resolve(TestProperty {
+            Form(
+                name: name,
+                data: data,
+                headers: {
+                    CustomHeader(name: "Accept-Language", value: "en-US")
+                    CustomHeader(name: "Accept-Language", value: "pt-BR")
+                }
+            )
+            .headerStrategy(.setting)
+        })
+
+        let parser = try await MultipartFormParser(resolved.request)
+        let parsed = try parser.parse()
+
+        // Then
+        XCTAssertEqual(
+            resolved.request.headers["Content-Type"],
+            ["multipart/form-data; boundary=\"\(parsed.boundary)\""]
+        )
+
+        XCTAssertEqual(
+            resolved.request.headers["Content-Length"],
+            [String(parser.buffers.lazy.map(\.estimatedBytes).reduce(.zero, +))]
+        )
+
+        XCTAssertEqual(parsed.items, [
+            PartForm(
+                headers: HTTPHeaders([
+                    ("Content-Disposition", "form-data; name=\"\(name)\""),
+                    ("Content-Type", "application/octet-stream"),
+                    ("Content-Length", String(data.count)),
+                    ("Accept-Language", "pt-BR")
+                ]),
+                contents: data
+            )
+        ])
+    }
+
     func testForm_whenBodyCalled_shouldBeNever() async throws {
         // Given
         let property = Form(


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

This PR changes the default value of `HeaderStrategy` when building your requests. Switch to `.adding` value makes more sense during implementation and reading the code. 

Fixes #166 

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
