### PR TITLE
Don't set `Content-Length` when payload is empty

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormItem.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormItem.swift
@@ -74,7 +74,10 @@ struct FormItem: Sendable {
 
         headers.set(name: "Content-Disposition", value: contentDisposition())
         headers.set(name: "Content-Type", value: String(contentType))
-        headers.set(name: "Content-Length", value: String(buffer.estimatedBytes))
+
+        if buffer.estimatedBytes > .zero {
+            headers.set(name: "Content-Length", value: String(buffer.estimatedBytes))
+        }
 
         if let additionalHeaders {
             headers = headers.merging(additionalHeaders) { lhs, _ in lhs }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormItem.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormItem.swift
@@ -74,10 +74,7 @@ struct FormItem: Sendable {
 
         headers.set(name: "Content-Disposition", value: contentDisposition())
         headers.set(name: "Content-Type", value: String(contentType))
-
-        if buffer.estimatedBytes > .zero {
-            headers.set(name: "Content-Length", value: String(buffer.estimatedBytes))
-        }
+        headers.set(name: "Content-Length", value: String(buffer.estimatedBytes))
 
         if let additionalHeaders {
             headers = headers.merging(additionalHeaders) { lhs, _ in lhs }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormNode.swift
@@ -48,10 +48,12 @@ struct FormNode: PropertyNode {
             buffers: buffers
         )
 
-        make.request.headers.set(
-            name: "Content-Length",
-            value: String(body.totalSize)
-        )
+        if body.totalSize > .zero {
+            make.request.headers.set(
+                name: "Content-Length",
+                value: String(body.totalSize)
+            )
+        }
 
         make.request.body = body
     }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormNode.swift
@@ -34,6 +34,11 @@ struct FormNode: PropertyNode {
     // MARK: - Internal methods
 
     func make(_ make: inout Make) async throws {
+        guard !items.isEmpty else {
+            removeAnySetHeaders(&make.request.headers)
+            return
+        }
+
         let constructor = FormGroupBuilder(items)
 
         make.request.headers.set(
@@ -48,13 +53,18 @@ struct FormNode: PropertyNode {
             buffers: buffers
         )
 
-        if body.totalSize > .zero {
-            make.request.headers.set(
-                name: "Content-Length",
-                value: String(body.totalSize)
-            )
-        }
+        make.request.headers.set(
+            name: "Content-Length",
+            value: String(body.totalSize)
+        )
 
         make.request.body = body
+    }
+
+    // MARK: - Private methods
+
+    private func removeAnySetHeaders(_ headers: inout HTTPHeaders) {
+        headers.remove(name: "Content-Type")
+        headers.remove(name: "Content-Length")
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadNode.swift
@@ -69,10 +69,12 @@ struct PayloadNode: PropertyNode {
             buffers: [buffer]
         )
 
-        make.request.headers.set(
-            name: "Content-Length",
-            value: String(body.totalSize)
-        )
+        if body.totalSize > .zero {
+            make.request.headers.set(
+                name: "Content-Length",
+                value: String(body.totalSize)
+            )
+        }
 
         make.request.body = body
     }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadNode.swift
@@ -36,6 +36,7 @@ struct PayloadNode: PropertyNode {
             let queries = queries.map { $0.build() }
 
             guard ![nil, "GET", "HEAD"].contains(make.request.method) else {
+                removeAnySetHeaders(&make.request.headers)
                 make.request.queries.append(contentsOf: queries)
                 return
             }
@@ -74,8 +75,15 @@ struct PayloadNode: PropertyNode {
                 name: "Content-Length",
                 value: String(body.totalSize)
             )
+        } else {
+            make.request.headers.remove(name: "Content-Length")
         }
 
         make.request.body = body
+    }
+
+    private func removeAnySetHeaders(_ headers: inout HTTPHeaders) {
+        headers.remove(name: "Content-Type")
+        headers.remove(name: "Content-Length")
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Form Group/FormGroupTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Form Group/FormGroupTests.swift
@@ -177,6 +177,22 @@ class FormGroupTests: XCTestCase {
         // Then
         try await assertNever(property.body)
     }
+
+    func testGroup_whenEmptyContent() async throws {
+        // When
+        let resolved = try await resolve(TestProperty {
+            FormGroup {}
+        })
+
+        let data = try await resolved.request.body?.data() ?? Data()
+
+        // Then
+        XCTAssertTrue(data.isEmpty)
+
+        XCTAssertNil(resolved.request.headers["Content-Type"])
+
+        XCTAssertNil(resolved.request.headers["Content-Length"])
+    }
 }
 
 extension FormGroupTests {

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Form/FormTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Form/FormTests.swift
@@ -1171,4 +1171,46 @@ class FormTests: XCTestCase {
         try await assertNever(property.body)
     }
 }
+
+extension FormTests {
+
+    func testForm_whenEmptyData() async throws {
+        // Given
+        let name = "foo"
+        let data = Data()
+
+        // When
+        let resolved = try await resolve(TestProperty {
+            Form(
+                name: name,
+                data: data
+            )
+        })
+
+        let parser = try await MultipartFormParser(resolved.request)
+        let parsed = try parser.parse()
+
+        // Then
+        XCTAssertEqual(
+            resolved.request.headers["Content-Type"],
+            ["multipart/form-data; boundary=\"\(parsed.boundary)\""]
+        )
+
+        XCTAssertEqual(
+            resolved.request.headers["Content-Length"],
+            [String(parser.buffers.lazy.map(\.estimatedBytes).reduce(.zero, +))]
+        )
+
+        XCTAssertEqual(parsed.items, [
+            PartForm(
+                headers: HTTPHeaders([
+                    ("Content-Disposition", "form-data; name=\"\(name)\""),
+                    ("Content-Type", "application/octet-stream"),
+                    ("Content-Length", String(data.count))
+                ]),
+                contents: data
+            )
+        ])
+    }
+}
 // swiftlint:enable file_length type_body_length function_body_length


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

Added a logic to skip the header `Content-Length` setting when payload is empty. Also, this PR fixes some configurations of body to keep the request well set.

Fixes #167 

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
