### PR TITLE
Changes default numberOfThreads to 1

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Session/Event Loop Manager/Models/MultiThreadedEventLoopGroup.swift
+++ b/Sources/RequestDL/Internals/Sources/Session/Event Loop Manager/Models/MultiThreadedEventLoopGroup.swift
@@ -7,7 +7,5 @@ import NIOPosix
 
 extension MultiThreadedEventLoopGroup {
 
-    static let shared = MultiThreadedEventLoopGroup(
-        numberOfThreads: ProcessInfo.processInfo.activeProcessorCount
-    )
+    static let shared = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 }


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

This updates the `numberOfThreads` to follow AsyncHTTPClient implementation. If developers need the request take advantage of multi core processors, they should use the `Session(_:numberOfThreads:)` instead.

Fixes #173 

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
