### PR TITLE
Implement `AcceptCharsetHeader`

### DIFF
--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Creating-requests-from-scratch.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Creating-requests-from-scratch.md
@@ -178,6 +178,7 @@ Learn more in:
 - ``RequestDL/OriginHeader``
 - ``RequestDL/RefererHeader``
 - ``RequestDL/CacheHeader``
+- ``RequestDL/AcceptCharsetHeader``
 - ``RequestDL/HeaderGroup``
 
 ### Changing the headers behavior

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Charset/AcceptCharsetHeader.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Charset/AcceptCharsetHeader.swift
@@ -1,0 +1,52 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+/**
+ Sets the `Accept-Charset` header in the request.
+
+ This is a specific feature that should be explored according to the needs of each endpoint. JSON in Swift, for
+ example, uses `UTF-8`, `UTF-16`, and `UTF-32` during decoding and fails if other charsets are used.
+ Therefore, always use this option only if it is truly necessary.
+*/
+public struct AcceptCharsetHeader: Property {
+
+    // MARK: - Public properties
+
+    /// Returns an exception since `Never` is a type that can never be constructed.
+    public var body: Never {
+        bodyException()
+    }
+
+    // MARK: - Private properties
+
+    private let charset: Charset
+
+    // MARK: - Inits
+
+    /**
+     Initializes a new instance for the given `Charset`.
+
+     - Parameter charset: The charset to be accepted. Defaults is UTF-8.
+     */
+    public init(_ charset: Charset) {
+        self.charset = charset
+    }
+
+    // MARK: - Public static methods
+
+    /// This method is used internally and should not be called directly.
+    public static func _makeProperty(
+        property: _GraphValue<AcceptCharsetHeader>,
+        inputs: _PropertyInputs
+    ) async throws -> _PropertyOutputs {
+        property.assertPathway()
+        return .leaf(HeaderNode(
+            key: "Accept-Charset",
+            value: property.charset.rawValue,
+            strategy: inputs.environment.headerStrategy
+        ))
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Charset/AcceptCharsetHeaderTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Charset/AcceptCharsetHeaderTests.swift
@@ -1,0 +1,48 @@
+/*
+ See LICENSE for this package's licensing information.
+ */
+
+import XCTest
+@testable import RequestDL
+
+class AcceptCharsetHeaderTests: XCTestCase {
+
+    func testCharset_whenUTF8() async throws {
+        // Given
+        let charset = Charset.utf8
+
+        // When
+        let resolved = try await resolve(TestProperty {
+            AcceptCharsetHeader(charset)
+        })
+
+        // Then
+        XCTAssertEqual(resolved.request.headers["Accept-Charset"], [charset.rawValue])
+    }
+
+    func testCharset_whenUTF16() async throws {
+        // Given
+        let charset = Charset.utf16
+
+        // When
+        let resolved = try await resolve(TestProperty {
+            AcceptCharsetHeader(charset)
+        })
+
+        // Then
+        XCTAssertEqual(resolved.request.headers["Accept-Charset"], [charset.rawValue])
+    }
+
+    func testCharset_whenUTF32() async throws {
+        // Given
+        let charset = Charset.utf32
+
+        // When
+        let resolved = try await resolve(TestProperty {
+            AcceptCharsetHeader(charset)
+        })
+
+        // Then
+        XCTAssertEqual(resolved.request.headers["Accept-Charset"], [charset.rawValue])
+    }
+}


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

This adds the `AcceptCharsetHeader` object to specify the `Accept-Charset` header, which is optionally but may be required in some environments. 

Fixes #139 

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
